### PR TITLE
Fix url escapes

### DIFF
--- a/airtable/airtable.py
+++ b/airtable/airtable.py
@@ -22,6 +22,7 @@ from requests.exceptions import HTTPError
 import posixpath
 import time
 from six.moves.urllib.parse import unquote
+from six.moves.urllib.parse import quote
 
 from .auth import AirtableAuth
 from .params import AirtableParams
@@ -43,7 +44,9 @@ class Airtable():
         session.auth = AirtableAuth(api_key=api_key)
         self.session = session
         self.table_name = table_name
-        self.url_table = posixpath.join(self.API_URL, base_key, table_name)
+        urlsafe_table_name = quote(table_name, safe='')
+        self.url_table = posixpath.join(self.API_URL, base_key,
+                                        urlsafe_table_name)
         self.is_authenticated = self.validate_session(self.url_table)
 
     def validate_session(self, url):

--- a/tests/test_url_fix.py
+++ b/tests/test_url_fix.py
@@ -1,0 +1,39 @@
+from airtable import Airtable
+import pytest
+from six.moves.urllib import parse
+
+
+@pytest.fixture
+def db_key():
+    return 'app0011kkk01'
+
+
+@pytest.fixture
+def table_names():
+    return {'Test table 1': 'Test%20table%201',
+            'Test/Table 2': 'Test%2FTable%202',
+            'Another (test) table': 'Another%20%28test%29%20table',
+            'A & test & table': 'A%20%26%20test%20%26%20table',
+            'percentage % table': 'percentage%20%25%20table'
+            }
+
+
+@pytest.fixture
+def baseurl(db_key):
+    url = parse.urljoin('https://api.airtable.com/v0/', db_key + '/')
+    return url
+
+
+def _make_url(url, table_escaped):
+    # return parse.urljoin(str(url + '/'), table_escaped)
+    return parse.urljoin(url, table_escaped)
+
+
+def test_url_escape(db_key, table_names, baseurl, monkeypatch):
+    def rettrue(*args):
+        return True
+    monkeypatch.setattr(Airtable, 'validate_session', rettrue)
+    print('baseurl: {}'.format(baseurl))
+    for name, escaped in table_names.items():
+        tmp_at = Airtable(base_key=db_key, table_name=name, api_key='key1234')
+        assert str(tmp_at.url_table) == _make_url(baseurl, escaped)

--- a/tests/test_url_fix.py
+++ b/tests/test_url_fix.py
@@ -5,11 +5,15 @@ from six.moves.urllib import parse
 
 @pytest.fixture
 def db_key():
+    """A fake database key for the url."""
     return 'app0011kkk01'
 
 
 @pytest.fixture
 def table_names():
+    """Dict of some test table names with characters that are not url safe with
+    url-escaped versions.
+    """
     return {'Test table 1': 'Test%20table%201',
             'Test/Table 2': 'Test%2FTable%202',
             'Another (test) table': 'Another%20%28test%29%20table',
@@ -20,20 +24,26 @@ def table_names():
 
 @pytest.fixture
 def baseurl(db_key):
+    """The base url for the database."""
     url = parse.urljoin('https://api.airtable.com/v0/', db_key + '/')
     return url
 
 
 def _make_url(url, table_escaped):
-    # return parse.urljoin(str(url + '/'), table_escaped)
+    """Build a url correctly for testing."""
     return parse.urljoin(url, table_escaped)
 
 
 def test_url_escape(db_key, table_names, baseurl, monkeypatch):
+    """Test for proper escaping of urls including unsafe characters in table
+    names (which airtable allows).
+    """
     def rettrue(*args):
         return True
+    # It's a fake url so don't try to validate it.
     monkeypatch.setattr(Airtable, 'validate_session', rettrue)
     print('baseurl: {}'.format(baseurl))
     for name, escaped in table_names.items():
         tmp_at = Airtable(base_key=db_key, table_name=name, api_key='key1234')
-        assert str(tmp_at.url_table) == _make_url(baseurl, escaped)
+        assert str(tmp_at.url_table) == _make_url(baseurl, escaped),\
+            "Class-generated url should be properly escaped."""

--- a/tests/test_url_fix.py
+++ b/tests/test_url_fix.py
@@ -46,4 +46,4 @@ def test_url_escape(db_key, table_names, baseurl, monkeypatch):
     for name, escaped in table_names.items():
         tmp_at = Airtable(base_key=db_key, table_name=name, api_key='key1234')
         assert str(tmp_at.url_table) == _make_url(baseurl, escaped),\
-            "Class-generated url should be properly escaped."""
+            "Class-generated url should be properly escaped."


### PR DESCRIPTION
Table names containing slashes cause an invalid url to be created and any get request throws an error. Using urllib.parse.quote to escape the name fixes this issue.

I've included a test for my code but unfortunately I couldn't run the main test suite. I used the library with this patch applied to download some records and it seemed to work fine, so it doesn't seem like I broke anything.