### PR TITLE
Add an example of how to search by checkbox

### DIFF
--- a/airtable/airtable.py
+++ b/airtable/airtable.py
@@ -312,6 +312,9 @@ class Airtable:
 
         >>> airtable.search('Gender', 'Male')
         [{'fields': {'Name': 'John', 'Gender': 'Male'}, ... ]
+        
+        >>> airtable.search('Checkbox Field', 1)
+        [{'fields': {'Name': 'John', 'Gender': 'Male'}, ... ]
 
         Args:
             field_name (``str``): Name of field to match (column name).


### PR DESCRIPTION
A common use-case of `search` is to filter all fields where a checkbox is checked/unchecked. Counterintuitively, passing any of "True" (string) or True (boolean) doesn't work. The way to get around this is by passing 1 or 0. This is undocumented until now.