### PR TITLE
Fix table test fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,9 +36,9 @@ def constants():
 @pytest.fixture()
 def table(constants):
     return Airtable(
-        constants["API_KEY"],
+        constants["BASE_KEY"],
         constants["TABLE_NAME"],
-        api_key=constants["BASE_KEY"]
+        api_key=constants["API_KEY"]
     )
 
 


### PR DESCRIPTION
API key and base key are in reverse in the table test fixture setup.