### PR TITLE
Implement Bulk Upload API Support and make typecast work with batch requests

### DIFF
--- a/airtable/airtable.py
+++ b/airtable/airtable.py
@@ -383,7 +383,7 @@ class Airtable:
 
         return self._post(
             self.url_table, json_data={"records": records, "typecast": typecast}
-        )
+        )['records']
 
     def chunker(self, seq):
         """
@@ -448,7 +448,7 @@ class Airtable:
 
         return self._patch(
             self.url_table, json_data={"records": records, "typecast": typecast}
-        )
+        )['records']
 
     def update(self, record_id=None, fields=None, typecast=False, records=None):
         """
@@ -631,7 +631,7 @@ class Airtable:
         params = {'records[]': record_ids}
         url_encoded_record_ids = urlencode(params, True)
         delete_url = '{}?{}'.format(self.url_table, url_encoded_record_ids)
-        return self._delete(delete_url)
+        return self._delete(delete_url)['records']
 
     def delete_by_field(self, field_name, field_value, **options):
         """

--- a/airtable/airtable.py
+++ b/airtable/airtable.py
@@ -479,7 +479,7 @@ class Airtable:
             record (``dict`` or ``list``): Updated record or list of updated records
         """
 
-        # if record_id is set, assume we are updating a single record
+        # if record_id and fields are set, assume we are updating a single record
         if record_id and fields:
             record_url = self.record_url(record_id)
             return self._patch(
@@ -534,7 +534,7 @@ class Airtable:
         >>> airtable.batch_update(records)
 
         Args:
-            records(``list``): Records to update
+            records(``Iterable``): Records to update
             typecast(``boolean``): Automatic data conversion from string values.
 
         Returns:

--- a/airtable/airtable.py
+++ b/airtable/airtable.py
@@ -427,7 +427,7 @@ class Airtable:
         Also used for batch_update
 
         >>> records = [airtable.match('Employee Id', 'DD13332454'), airtable.match('Employee Id', 'DD12312378')]
-        >>> updates = [{'id': records[0]['id'], 'Status': 'Fired'}, {'id': records[1]['id'], 'Status': 'Hired'}]
+        >>> updates = [{'id': records[0]['id'], 'fields': {'Status': 'Fired'}}, {'id': records[1]['id'], 'fields': {'Status': 'Hired'}}]
         >>> airtable.update_records(updates)
 
         Args:
@@ -464,7 +464,7 @@ class Airtable:
         Update multiple records:
 
         >>> records = [airtable.match('Employee Id', 'DD13332454'), airtable.match('Employee Id', 'DD12312378')]
-        >>> updates = [{'id': records[0]['id'], 'Status': 'Fired'}, {'id': records[1]['id'], 'Status': 'Hired'}]
+        >>> updates = [{'id': records[0]['id'], 'fields': {'Status': 'Fired'}}, {'id': records[1]['id'], 'fields': {'Status': 'Hired'}}]
         >>> airtable.update(records=updates)
 
         Args:
@@ -530,8 +530,9 @@ class Airtable:
         To change the rate limit use ``airtable.API_LIMIT = 0.2``
         (5 per second)
 
-        >>> records = [{'id': 'recXXXXXXXXXXXXXX', 'Name': 'John'}, {'id': 'recYYYYYYYYYYYYYY', 'Name': 'Marc'}]
-        >>> airtable.batch_update(records)
+        >>> records = [airtable.match('Employee Id', 'DD13332454'), airtable.match('Employee Id', 'DD12312378')]
+        >>> updates = [{'id': records[0]['id'], 'fields': {'Status': 'Fired'}}, {'id': records[1]['id'], 'fields': {'Status': 'Hired'}}]
+        >>> airtable.batch_update(updates)
 
         Args:
             records(``Iterable``): Records to update

--- a/airtable/airtable.py
+++ b/airtable/airtable.py
@@ -374,7 +374,7 @@ class Airtable:
             )
 
         # otherwise, assume an iterable of records was passed in.
-        records = list(fields_or_records)
+        records = [{'fields': fields} for fields in fields_or_records]
 
         if len(records) > self.MAX_RECORDS_PER_CALL:
             raise RuntimeError(
@@ -431,7 +431,7 @@ class Airtable:
         >>> airtable.update_records(updates)
 
         Args:
-            records(``Iterable``): Iterable of dictionaries with Column names as Key and 'id' equal to Id of Record.
+            records(``Iterable``): Iterable of dictionaries with 'fields' equal to a dictionary of Column names as Key and 'id' equal to Id of Record.
             typecast(``boolean``): Automatic data conversion from string values.
 
         Returns:
@@ -472,7 +472,7 @@ class Airtable:
             fields(``dict``): Fields to update (if updating single record)
                 Must be dictionary with Column names as Key
             typecast(``boolean``): Automatic data conversion from string values.
-            records(``Iterable``): Iterable of dictionaries with Column names as Key and 'id' equal to Id of Record.
+            records(``Iterable``): Iterable of dictionaries with 'fields' equal to a dictionary of Column names as Key and 'id' equal to Id of Record.
                 Only required if updating multiple records.
 
         Returns:
@@ -488,7 +488,7 @@ class Airtable:
 
         # otherwise, check for records:
         if records:
-            self.update_records(records)
+            return self.update_records(records)
 
         # inputs were not set correctly
         raise RuntimeError(


### PR DESCRIPTION
This is an implementation of https://github.com/gtalarico/airtable-python-wrapper/issues/35

1. insert, update, and delete can now do up to 10 rows in a single request
2. added batch_update
3. batch_insert, batch_update, and batch_delete make one request per 10 records
4. batch methods now support typecast