### PR TITLE
Rewrites delete() and batch_delete() to support bulk delete per request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,11 @@ docs/build
 .tox
 *egg-info
 *__pycache__
+*.pyc
 .pytest_cache
 .cache
 coverage.xml
 .coverage
 test.py
+.python-version
+.mypy_cache

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,7 @@
+import random
+import string
+from datetime import datetime
+import time
 import pytest
 from collections import OrderedDict
 from posixpath import join as urljoin
@@ -7,6 +11,12 @@ from six.moves.urllib.parse import urlencode, quote
 from mock import Mock
 
 from airtable import Airtable
+
+
+def rand_string_letter_digit(length):
+    return "".join(
+        random.choice(string.ascii_letters + string.digits) for _ in range(length)
+    )
 
 
 @pytest.fixture
@@ -57,6 +67,25 @@ def mock_records():
             "createdTime": "2017-06-06T18:30:57.000Z",
         },
     ]
+
+
+@pytest.fixture
+def create_random_record():
+    return lambda: {
+        "id": "rec" + rand_string_letter_digit(14),
+        "fields": {
+            "SameFields": random.randint(100, 9999),
+            "Value": rand_string_letter_digit(5),
+        },
+        "createdTime": datetime.fromtimestamp(
+            random.randint(1, int(time.time()))
+        ).isoformat(),
+    }
+
+
+@pytest.fixture
+def create_random_records(create_random_record):
+    return lambda size: [create_random_record() for _ in range(size)]
 
 
 @pytest.fixture

--- a/tests/test_airtable_class.py
+++ b/tests/test_airtable_class.py
@@ -201,7 +201,7 @@ def test_replace_by_field(table, mock_response_single):
 
 def test_delete(table, mock_response_single):
     id_ = mock_response_single["id"]
-    expected = {"delete": True, "id": id_}
+    expected = {"deleted": True, "id": id_}
     with Mocker() as mock:
         mock.delete(urljoin(table.url_table, id_), status_code=201, json=expected)
         resp = table.delete(id_)
@@ -236,7 +236,7 @@ def test_delete_over_limit(table, create_random_records):
 
 def test_delete_by_field(table, mock_response_single):
     id_ = mock_response_single["id"]
-    expected = {"delete": True, "id": id_}
+    expected = {"deleted": True, "id": id_}
     match_params = urlencode({"FilterByFormula": "{Value}='abc'"})
     match_url = table.url_table + "?" + match_params
     with Mocker() as mock:
@@ -257,11 +257,11 @@ def test_batch_delete(table, mock_records):
             mock.delete(
                 urljoin(table.url_table, id_),
                 status_code=201,
-                json={"delete": True, "id": id_},
+                json={"deleted": True, "id": id_},
             )
         records = [i["id"] for i in mock_records]
         resp = table.batch_delete(records)
-    expected = [{"delete": True, "id": i} for i in ids]
+    expected = [{"deleted": True, "id": i} for i in ids]
     assert resp == expected
 
 


### PR DESCRIPTION
Hi, I came upon this repo and found it super useful in my personal project. The new bulk support of Airtable API looks nice, so I decided to give it a try to add it to this library. 

I tried not to change the behavior of existing public methods. I found that batch_xxx methods call `_batch_request()`, so to not change too much code, I decided to let `delete()` accepts multiple ids, and made `batch_delete()` call it repeatedly. Since `batch_delete()`'s behavior changed so much, I had to change the test for it.

I also fixed some typos in the tests along the way. If this PR goes well, I would like to add bulk support to methods as well.