### PR TITLE
Simplify

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 git:
   depth: 2
 python:
-  - "2.7"
   - "3.5"
   - "3.6"
   - "3.7"

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,7 +1,8 @@
 # 0.15.0
 * **Breaking**: Drop Api config from ENV variable - use `api_key` arg instead
 * **Breaking**: Drop Python 2 / IronPython Support
-
+* **Breaking**: Removed "delete_by_field" - use match and then delete
+* Feature: Inject HTTP Error message into exception
 
 # 0.14.0
 * Removed: `mirror()` method.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,4 @@
-# 0.15.0
+# 0.15.0 (WIP)
 * **Breaking**: Drop Api config from ENV variable - use `api_key` arg instead
 * **Breaking**: Drop Python 2 / IronPython Support
 * Feature: On HTTP Errors, Raise Original Exception, but with Helpful Errors added

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,8 +1,7 @@
 # 0.15.0
 * **Breaking**: Drop Api config from ENV variable - use `api_key` arg instead
 * **Breaking**: Drop Python 2 / IronPython Support
-* **Breaking**: Removed "delete_by_field" - use match and then delete
-* Feature: Inject HTTP Error message into exception
+* Feature: On HTTP Errors, Raise Original Exception, but with Helpful Errors added
 
 # 0.14.0
 * Removed: `mirror()` method.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,6 @@
 # 0.15.0
 * **Breaking**: Drop Api config from ENV variable - use `api_key` arg instead
+* **Breaking**: Drop Python 2 / IronPython Support
 
 
 # 0.14.0

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
+# 0.15.0
+* **Breaking**: Drop Api config from ENV variable - use `api_key` arg instead
+
+
 # 0.14.0
-* Removed `mirror()` method.
+* Removed: `mirror()` method.
 * Feature: Configurable request timeout
 
 # 0.13.0

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 * **Breaking**: Drop Api config from ENV variable - use `api_key` arg instead
 * **Breaking**: Drop Python 2 / IronPython Support
 * Feature: On HTTP Errors, Raise Original Exception, but with Helpful Errors added
+* Fix: #86 formulas with string values
 
 # 0.14.0
 * Removed: `mirror()` method.

--- a/airtable/__init__.py
+++ b/airtable/__init__.py
@@ -1,2 +1,1 @@
-from __future__ import absolute_import
 from .airtable import Airtable  # noqa

--- a/airtable/airtable.py
+++ b/airtable/airtable.py
@@ -171,9 +171,8 @@ class Airtable(object):
             else:
                 if "error" in error_dict:
                     err_msg += " [Error: {}]".format(error_dict["error"])
-            # TODO raise original exc instead to pass full HTTP error and response
-            # exc.args = (*exc.args, exc.response.json())
-            raise requests.exceptions.HTTPError(err_msg)
+            exc.args = (*exc.args, err_msg)
+            raise exc
         else:
             return response.json()
 

--- a/airtable/airtable.py
+++ b/airtable/airtable.py
@@ -90,20 +90,14 @@ similar to this:
 
 """  #
 
-import sys
 import requests
 from collections import OrderedDict
 import posixpath
 import time
-from six.moves.urllib.parse import unquote, quote
+from urllib.parse import unquote, quote
 
 from .auth import AirtableAuth
 from .params import AirtableParams
-
-try:
-    IS_IPY = sys.implementation.name == "ironpython"
-except AttributeError:
-    IS_IPY = False
 
 
 class Airtable(object):
@@ -168,13 +162,6 @@ class Airtable(object):
             response.raise_for_status()
         except requests.exceptions.HTTPError as exc:
             err_msg = str(exc)
-
-            # Reports Decoded 422 Url for better troubleshooting
-            # Disabled in IronPython Bug:
-            # https://github.com/IronLanguages/ironpython2/issues/242
-            if not IS_IPY and response.status_code == 422:
-                err_msg = err_msg.replace(response.url, unquote(response.url))
-                err_msg += " (Decoded URL)"
 
             # Attempt to get Error message from response, Issue #16
             try:

--- a/airtable/airtable.py
+++ b/airtable/airtable.py
@@ -94,7 +94,7 @@ import requests
 from collections import OrderedDict
 import posixpath
 import time
-from urllib.parse import unquote, quote
+from urllib.parse import quote
 
 from .auth import AirtableAuth
 from .params import AirtableParams

--- a/airtable/airtable.py
+++ b/airtable/airtable.py
@@ -114,7 +114,7 @@ class Airtable(object):
     API_URL = posixpath.join(API_BASE_URL, VERSION)
     MAX_RECORDS_PER_REQUEST = 10
 
-    def __init__(self, base_key, table_name, api_key=None, timeout=None):
+    def __init__(self, base_key, table_name, api_key, timeout=None):
         """
         Instantiates a new Airtable instance
 
@@ -128,10 +128,9 @@ class Airtable(object):
             base_key(``str``): Airtable base identifier
             table_name(``str``): Airtable table name. Value will be url encoded, so
                 use value as shown in Airtable.
+            api_key (``str``): API key.
 
         Keyword Args:
-            api_key (``str``, optional): Optional API key. If not provided,
-                it will attempt to use ``os.environ['AIRTABLE_API_KEY']``
             timeout (``int``, ``Tuple[int, int]``, optional): Optional timeout
                 parameters to be used in request. `See requests timeout docs.
                 <https://requests.readthedocs.io/en/master/user/advanced/#timeouts>`_
@@ -159,10 +158,10 @@ class Airtable(object):
     def _chunk(self, iterable, chunk_size):
         """Break iterable into chunks."""
         for i in range(0, len(iterable), chunk_size):
-            yield iterable[i:i + chunk_size]
+            yield iterable[i : i + chunk_size]
 
     def _build_batch_record_objects(self, records):
-        return [{'fields': record} for record in records]
+        return [{"fields": record} for record in records]
 
     def _process_response(self, response):
         try:
@@ -216,8 +215,7 @@ class Airtable(object):
         return self._request("delete", url)
 
     def _delete_batch(self, record_ids):
-        return self._request("delete", self.url_table,
-                             params={'records': record_ids})
+        return self._request("delete", self.url_table, params={"records": record_ids})
 
     def get(self, record_id):
         """
@@ -416,9 +414,10 @@ class Airtable(object):
         inserted_records = []
         for chunk in self._chunk(records, self.MAX_RECORDS_PER_REQUEST):
             new_records = self._build_batch_record_objects(chunk)
-            response = self._post(self.url_table, json_data={
-                "records": new_records, "typecast": typecast})
-            inserted_records += response['records']
+            response = self._post(
+                self.url_table, json_data={"records": new_records, "typecast": typecast}
+            )
+            inserted_records += response["records"]
             time.sleep(self.API_LIMIT)
         return inserted_records
 
@@ -586,7 +585,7 @@ class Airtable(object):
         deleted_records = []
         for chunk in chunks:
             response = self._delete_batch(chunk)
-            deleted_records += response['records']
+            deleted_records += response["records"]
             time.sleep(self.API_LIMIT)
         return deleted_records
 

--- a/airtable/auth.py
+++ b/airtable/auth.py
@@ -1,13 +1,7 @@
 """
 Authentication is handled by the :any:`Airtable` class.
-The class can handle authentication automatically
-if the environment variable `AIRTABLE_API_KEY` is set with your api key.
 
->>> airtable = Airtable(base_key, table_name)
-
-Alternatively, you can pass the key explicitly:
-
->>> airtable = Airtable(base_key, table_name, api_key='yourapikey')
+>>> airtable = Airtable(base_key, table_name, api_key)
 
 Note:
     You can also use this class to handle authentication for you if you
@@ -17,8 +11,6 @@ Note:
     >>> response = requests.get('https://api.airtable.com/v0/{basekey}/{table_name}', auth=auth)
 
 """  #
-from __future__ import absolute_import
-import os
 import requests
 
 
@@ -30,8 +22,7 @@ class AirtableAuth(requests.auth.AuthBase):
         Args:
             api_key (``str``): Airtable API Key.
         """
-        try:
-            self.api_key = api_key
+        self.api_key = api_key
 
     def __call__(self, request):
         auth_token = {"Authorization": "Bearer {}".format(self.api_key)}

--- a/airtable/auth.py
+++ b/airtable/auth.py
@@ -23,22 +23,15 @@ import requests
 
 
 class AirtableAuth(requests.auth.AuthBase):
-    def __init__(self, api_key=None):
+    def __init__(self, api_key):
         """
         Authentication used by Airtable Class
 
         Args:
-            api_key (``str``): Airtable API Key. Optional.
-                If not set, it will look for
-                enviroment variable ``AIRTABLE_API_KEY``
+            api_key (``str``): Airtable API Key.
         """
         try:
-            self.api_key = api_key or os.environ["AIRTABLE_API_KEY"]
-        except KeyError:
-            raise KeyError(
-                "Api Key not found. Pass api_key as a kwarg \
-                            or set an env var AIRTABLE_API_KEY with your key"
-            )
+            self.api_key = api_key
 
     def __call__(self, request):
         auth_token = {"Authorization": "Bearer {}".format(self.api_key)}

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(os.path.join(here, "airtable", "__version__.py"), mode="r") as f:
     exec(f.read(), about)
 
 setup_requires = ["pytest-runner"]
-install_requires = ["requests>=2", "six>=1.10"]
+install_requires = ["requests>=2"]
 tests_require = ["requests-mock", "requests", "mock"]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     setup_requires=setup_requires,
     install_requires=install_requires,
     tests_require=tests_require,
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
+    python_requires="!=2.7.*, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
     keywords=["airtable", "api"],
     license=about["__license__"],
     classifiers=[
@@ -32,7 +32,6 @@ setup(
         "Programming Language :: Python",
         "Topic :: Software Development",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -93,8 +93,7 @@ def mock_response_iterator(mock_response_list):
     i = iter(mock_response_list)
 
     def _response_iterator(request, context):
-        v = next(i)
-        return v
+        return next(i)
 
     return _response_iterator
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 from posixpath import join as urljoin
 
 from requests import HTTPError
-from six.moves.urllib.parse import urlencode, quote
+from urllib.parse import urlencode, quote
 from mock import Mock
 
 from airtable import Airtable

--- a/tests/test_airtable_class.py
+++ b/tests/test_airtable_class.py
@@ -1,7 +1,7 @@
 import pytest
 from posixpath import join as urljoin
 from requests_mock import Mocker
-from six.moves.urllib.parse import urlencode
+from urllib.parse import urlencode
 
 from airtable import Airtable
 
@@ -127,9 +127,7 @@ def test_batch_insert(table, mock_records):
     with Mocker() as mock:
         for chunk in _chunk(mock_records, 10):
             mock.post(
-                table.url_table,
-                status_code=201,
-                json={'records': chunk},
+                table.url_table, status_code=201, json={"records": chunk},
             )
         records = [i["fields"] for i in mock_records]
         resp = table.batch_insert(records)
@@ -235,12 +233,12 @@ def test_batch_delete(table, mock_records):
     ids = [i["id"] for i in mock_records]
     with Mocker() as mock:
         for chunk in _chunk(ids, 10):
-            params = [('records', id_) for id_ in chunk]
+            params = [("records", id_) for id_ in chunk]
             params_encode = urlencode(params)
             mock.delete(
-                table.url_table + '?' + params_encode,
+                table.url_table + "?" + params_encode,
                 status_code=201,
-                json={'records': [{"delete": True, "id": id_} for id_ in chunk]},
+                json={"records": [{"delete": True, "id": id_} for id_ in chunk]},
             )
 
         resp = table.batch_delete(ids)
@@ -250,9 +248,10 @@ def test_batch_delete(table, mock_records):
 
 # Helpers
 
+
 def _chunk(iterable, chunk_size):
     for i in range(0, len(iterable), chunk_size):
-        yield iterable[i:i + chunk_size]
+        yield iterable[i : i + chunk_size]
 
 
 def match_request_data(post_data):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -23,7 +23,3 @@ class TestAuth(object):
         assert "Authorization" in request.headers
         assert "Bearer" in request.headers["Authorization"]
 
-    def test_authorization_missing(self):
-        os.environ.pop("AIRTABLE_API_KEY", None)
-        with pytest.raises(KeyError):
-            AirtableAuth()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,5 +1,3 @@
-import pytest
-import os
 import requests
 from requests_mock import Mocker
 from airtable.auth import AirtableAuth
@@ -22,4 +20,3 @@ class TestAuth(object):
         request = auth.__call__(request)
         assert "Authorization" in request.headers
         assert "Bearer" in request.headers["Authorization"]
-

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import pytest
 import requests
 from requests_mock import Mocker

--- a/tests/test_request_errors.py
+++ b/tests/test_request_errors.py
@@ -3,14 +3,6 @@ from requests import HTTPError
 from mock import Mock
 
 
-def http_error_with_url():
-    raise HTTPError("unable to process page%20url")
-
-
-def json_decoder_error():
-    raise ValueError()
-
-
 def test_error_mesg_in_json(table, response):
     response.status_code = 400
     response.json = Mock(return_value={"error": "here's what went wrong"})

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35,py36,py37,py38,lint
+envlist = py35,py36,py37,py38,lint
 
 [flake8]
 filename = *.py


### PR DESCRIPTION
* **Breaking**: Drop Api config from ENV variable - use `api_key` arg instead
* **Breaking**: Drop Python 2 / IronPython Support
* Feature: Inject HTTP Error message into exception (#83)

### PY2
Drop Python 2 Support

### ENV config
Just use `api_key` instead, and get it yourself with `os.environ["AIRTABLE_API_KEY"]`

### Fix for #83 
Original HTTP error will be raised eg-.

```python 
try:
    airtable.insert(...)
except HTTPError as exc:
   print(exc.response.status_code)
```