### PR TITLE
Fix 422 error when calling batch_delete on a single record

### DIFF
--- a/airtable/airtable.py
+++ b/airtable/airtable.py
@@ -203,6 +203,9 @@ class Airtable(object):
         return self._request("delete", url)
 
     def _delete_batch(self, record_ids):
+        if len(record_ids) == 1:
+            return self.delete(record_ids[0])
+
         return self._request("delete", self.url_table, params={"records": record_ids})
 
     def get(self, record_id):
@@ -573,7 +576,7 @@ class Airtable(object):
         deleted_records = []
         for chunk in chunks:
             response = self._delete_batch(chunk)
-            deleted_records += response["records"]
+            deleted_records += response["records"] if len(chunk) > 1 else [response]
             time.sleep(self.API_LIMIT)
         return deleted_records
 

--- a/tests/test_airtable_class.py
+++ b/tests/test_airtable_class.py
@@ -238,8 +238,11 @@ def test_batch_delete(table, mock_records):
             json = (
                 {"records": [{"delete": True, "id": id_} for id_ in chunk]} if len(chunk) > 1
                 else {"delete": True,  "id": chunk[0]})
+            url = (
+                table.url_table + "?" + params_encode if len(chunk) > 1 
+                else urljoin(table.url_table, chunk[0]))
             mock.delete(
-                table.url_table + "?" + params_encode,
+                url,
                 status_code=201,
                 json=json,
             )

--- a/tests/test_airtable_class.py
+++ b/tests/test_airtable_class.py
@@ -235,10 +235,13 @@ def test_batch_delete(table, mock_records):
         for chunk in _chunk(ids, 10):
             params = [("records", id_) for id_ in chunk]
             params_encode = urlencode(params)
+            json = (
+                {"records": [{"delete": True, "id": id_} for id_ in chunk]} if len(chunk) > 1
+                else {"delete": True,  "id": chunk[0]})
             mock.delete(
                 table.url_table + "?" + params_encode,
                 status_code=201,
-                json={"records": [{"delete": True, "id": id_} for id_ in chunk]},
+                json=json,
             )
 
         resp = table.batch_delete(ids)

--- a/tests/test_airtable_class.py
+++ b/tests/test_airtable_class.py
@@ -127,7 +127,9 @@ def test_batch_insert(table, mock_records):
     with Mocker() as mock:
         for chunk in _chunk(mock_records, 10):
             mock.post(
-                table.url_table, status_code=201, json={"records": chunk},
+                table.url_table,
+                status_code=201,
+                json={"records": chunk},
             )
         records = [i["fields"] for i in mock_records]
         resp = table.batch_insert(records)
@@ -236,11 +238,15 @@ def test_batch_delete(table, mock_records):
             params = [("records", id_) for id_ in chunk]
             params_encode = urlencode(params)
             json = (
-                {"records": [{"delete": True, "id": id_} for id_ in chunk]} if len(chunk) > 1
-                else {"delete": True,  "id": chunk[0]})
+                {"records": [{"delete": True, "id": id_} for id_ in chunk]}
+                if len(chunk) > 1
+                else {"delete": True, "id": chunk[0]}
+            )
             url = (
-                table.url_table + "?" + params_encode if len(chunk) > 1 
-                else urljoin(table.url_table, chunk[0]))
+                table.url_table + "?" + params_encode
+                if len(chunk) > 1
+                else urljoin(table.url_table, chunk[0])
+            )
             mock.delete(
                 url,
                 status_code=201,
@@ -250,6 +256,7 @@ def test_batch_delete(table, mock_records):
         resp = table.batch_delete(ids)
     expected = [{"delete": True, "id": i} for i in ids]
     assert resp == expected
+
 
 def test_batch_delete_single_record(table, mock_response_single):
     test_batch_delete(table, [mock_response_single])

--- a/tests/test_airtable_class.py
+++ b/tests/test_airtable_class.py
@@ -245,6 +245,9 @@ def test_batch_delete(table, mock_records):
     expected = [{"delete": True, "id": i} for i in ids]
     assert resp == expected
 
+def test_batch_delete_single_record(table, mock_response_single):
+    test_batch_delete(table, [mock_response_single])
+
 
 # Helpers
 


### PR DESCRIPTION
Surfaced in issue #94 . (cc @cuchoi)

The Airtable API has two deletion endpoints. The batch endpoint deletes multiple records from a table at once, while the record endpoint deletes one record. 

The API documentation says to "issue a DELETE request to the record endpoint to delete a single record." The batch_delete function errors because it sends DELETE requests with one record to the batch endpoint. 

The batch_delete function takes multiple records and sends them to the batch endpoint in chunks of up to n records at a time. The error case occurs if a chunk has just one record. This happens in two cases: i) the method is called on just one record, or ii) number_of_records > n with number_of_records % n == 1, i.e. after splitting the records into chunks of size n there is one record remaining, leaving a final chunk with 1 record.

These changes resolve the error by checking if a chunk contains just one record and, if so, calling the record deletion endpoint instead of the batch endpoint. They also add test coverage for calling batch_delete on a single record.