### PR TITLE
Escape single quotes in formula field_value

### DIFF
--- a/airtable/params.py
+++ b/airtable/params.py
@@ -205,7 +205,7 @@ class AirtableParams(object):
             Creates a formula to match cells from from field_name and value
             """
             if isinstance(field_value, str):
-                field_value = "'{}'".format(field_value)
+                field_value = "'{}'".format(field_value.replace("'", "\\'"))
 
             formula = "{{{name}}}={value}".format(name=field_name, value=field_value)
             return formula


### PR DESCRIPTION
I encountered a bug where Airtable responds with a 422 error when a formula value contains a single quote or apostrophe. For example, a string like "Men's Clothing" is incompatible with the single quotes used to wrap the formula. Escaping the single quote resolved the issue. This library makes my life better on a daily basis so the least I can do is contribute a (very small) improvement. Hope this is useful, thanks!