### PR TITLE
move base_key to base_id to match airtable nomenclature

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ For the full list and documentation visit the [docs](http://airtable-python-wrap
 You can see the wrapper in action in this [Jupyter Notebook](https://github.com/gtalarico/airtable-python-wrapper/blob/master/Airtable.ipynb).
 
 ```
-airtable = Airtable('baseKey', 'table_name')
+airtable = Airtable('base_id', 'table_name')
 
 airtable.get_all(view='MyView', maxRecords=20)
 

--- a/airtable/airtable.py
+++ b/airtable/airtable.py
@@ -3,7 +3,7 @@
 Airtable Class Instance
 ***********************
 
->>> airtable = Airtable('base_key', 'table_name')
+>>> airtable = Airtable('base_id', 'table_name')
 >>> airtable.get_all()
 [{id:'rec123asa23', fields': {'Column': 'Value'}, ...}]
 
@@ -108,18 +108,18 @@ class Airtable(object):
     API_URL = posixpath.join(API_BASE_URL, VERSION)
     MAX_RECORDS_PER_REQUEST = 10
 
-    def __init__(self, base_key, table_name, api_key, timeout=None):
+    def __init__(self, base_id, table_name, api_key, timeout=None):
         """
         Instantiates a new Airtable instance
 
-        >>> table = Airtable('basekey', "tablename")
+        >>> table = Airtable('base_id', "tablename")
 
         With timeout:
 
-        >>> table = Airtable('basekey', "tablename", timeout=(1, 1))
+        >>> table = Airtable('base_id', "tablename", timeout=(1, 1))
 
         Args:
-            base_key(``str``): Airtable base identifier
+            base_id(``str``): Airtable base identifier
             table_name(``str``): Airtable table name. Value will be url encoded, so
                 use value as shown in Airtable.
             api_key (``str``): API key.
@@ -135,7 +135,7 @@ class Airtable(object):
         self.session = session
         self.table_name = table_name
         url_safe_table_name = quote(table_name, safe="")
-        self.url_table = posixpath.join(self.API_URL, base_key, url_safe_table_name)
+        self.url_table = posixpath.join(self.API_URL, base_id, url_safe_table_name)
         self.timeout = timeout
 
     def _process_params(self, params):

--- a/airtable/auth.py
+++ b/airtable/auth.py
@@ -1,14 +1,14 @@
 """
 Authentication is handled by the :any:`Airtable` class.
 
->>> airtable = Airtable(base_key, table_name, api_key)
+>>> airtable = Airtable(base_id, table_name, api_key)
 
 Note:
     You can also use this class to handle authentication for you if you
     are making your own wrapper:
 
     >>> auth = AirtableAuth(api_key)
-    >>> response = requests.get('https://api.airtable.com/v0/{basekey}/{table_name}', auth=auth)
+    >>> response = requests.get('https://api.airtable.com/v0/{base_id}/{table_name}', auth=auth)
 
 """  #
 import requests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,9 +13,9 @@ from airtable import Airtable
 def url_builder():
     """ Builds Airtable Api Url Manually for mock testing """
 
-    def _url_builder(base_key, table_name, params=None):
+    def _url_builder(base_id, table_name, params=None):
         urltable_name = quote(table_name, safe="")
-        url = urljoin(Airtable.API_URL, base_key, urltable_name)
+        url = urljoin(Airtable.API_URL, base_id, urltable_name)
         if params:
             params = OrderedDict(sorted(params.items()))
             url += "?" + urlencode(params)
@@ -27,14 +27,14 @@ def url_builder():
 @pytest.fixture
 def constants():
     return dict(
-        API_KEY="FakeApiKey", BASE_KEY="appJMY16gZDQrMWpA", TABLE_NAME="Table Name"
+        API_KEY="FakeApiKey", BASE_ID="appJMY16gZDQrMWpA", TABLE_NAME="Table Name"
     )
 
 
 @pytest.fixture()
 def table(constants):
     return Airtable(
-        constants["BASE_KEY"], constants["TABLE_NAME"], api_key=constants["API_KEY"]
+        constants["BASE_ID"], constants["TABLE_NAME"], api_key=constants["API_KEY"]
     )
 
 

--- a/tests/test_airtable_class.py
+++ b/tests/test_airtable_class.py
@@ -11,15 +11,15 @@ def test_repr(table):
 
 
 @pytest.mark.parametrize(
-    "base_key,table_name,table_url_suffix",
+    "base_id,table_name,table_url_suffix",
     [
         ("abc", "My Table", "abc/My%20Table"),
         ("abc", "SomeTable", "abc/SomeTable"),
         ("abc", "Table-fake", "abc/Table-fake"),
     ],
 )
-def test_url(base_key, table_name, table_url_suffix):
-    table = Airtable(base_key, table_name, api_key="x")
+def test_url(base_id, table_name, table_url_suffix):
+    table = Airtable(base_id, table_name, api_key="x")
     assert table.url_table == "{0}/{1}".format(table.API_URL, table_url_suffix)
 
 


### PR DESCRIPTION
I didn't update the notebook but the library and docs now match the airtable api nomenclature.

I would suggest moving the library to `python-airtable` to create a pypi semantically pretty package name.