### PR TITLE
Fix typo in documentation for batch_update

### DIFF
--- a/airtable/airtable.py
+++ b/airtable/airtable.py
@@ -440,7 +440,7 @@ class Airtable(object):
         Updates a records by their record id's in batch.
 
         Args:
-            records(``list``): List of dict: [{"id": record_id, "field": fields_to_update_dict}]
+            records(``list``): List of dict: [{"id": record_id, "fields": fields_to_update_dict}]
             typecast(``boolean``): Automatic data conversion from string values.
 
         Returns:


### PR DESCRIPTION
Fixed a minor typo in the `batch_update` function documentation. Using `field` in the record dictionary leads to a key error that is solved by using `fields` instead.