### PR TITLE
Escape single quote formula field

### DIFF
--- a/airtable/params.py
+++ b/airtable/params.py
@@ -17,6 +17,7 @@ For more information see the full implementation below.
 """  #
 
 from collections import OrderedDict
+import re
 
 
 class _BaseParam(object):
@@ -65,7 +66,7 @@ class _BaseObjectArrayParam(_BaseParam):
     """
 
     def to_param_dict(self):
-        """ Sorts to ensure Order is consistent for Testing """
+        """Sorts to ensure Order is consistent for Testing"""
         param_dict = {}
         for index, dictionary in enumerate(self.value):
             for key, value in dictionary.items():
@@ -205,6 +206,7 @@ class AirtableParams(object):
             Creates a formula to match cells from from field_name and value
             """
             if isinstance(field_value, str):
+                field_value = re.sub("(?<!\\\\)'", "\\'", field_value)
                 field_value = "'{}'".format(field_value)
 
             formula = "{{{name}}}={value}".format(name=field_name, value=field_value)
@@ -358,7 +360,7 @@ class AirtableParams(object):
 
     @classmethod
     def _get(cls, kwarg_name):
-        """ Returns a Param Class Instance, by its kwarg or param name """
+        """Returns a Param Class Instance, by its kwarg or param name"""
         param_classes = cls._discover_params()
         try:
             param_class = param_classes[kwarg_name]

--- a/airtable/params.py
+++ b/airtable/params.py
@@ -66,7 +66,7 @@ class _BaseObjectArrayParam(_BaseParam):
     """
 
     def to_param_dict(self):
-        """Sorts to ensure Order is consistent for Testing"""
+        """ Sorts to ensure Order is consistent for Testing """
         param_dict = {}
         for index, dictionary in enumerate(self.value):
             for key, value in dictionary.items():
@@ -360,7 +360,7 @@ class AirtableParams(object):
 
     @classmethod
     def _get(cls, kwarg_name):
-        """Returns a Param Class Instance, by its kwarg or param name"""
+        """ Returns a Param Class Instance, by its kwarg or param name """
         param_classes = cls._discover_params()
         try:
             param_class = param_classes[kwarg_name]

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -80,7 +80,7 @@ class TestParamsIntegration(object):
     ],
 )
 def test_process_params(kwargs, url_params):
-    """Ensure kwargs received build a proper params"""
+    """ Ensure kwargs received build a proper params """
     # https://codepen.io/airtable/full/rLKkYB
 
     FAKE_URL = "http://www.fake.com"

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -80,7 +80,7 @@ class TestParamsIntegration(object):
     ],
 )
 def test_process_params(kwargs, url_params):
-    """ Ensure kwargs received build a proper params """
+    """Ensure kwargs received build a proper params"""
     # https://codepen.io/airtable/full/rLKkYB
 
     FAKE_URL = "http://www.fake.com"
@@ -93,6 +93,12 @@ def test_process_params(kwargs, url_params):
 def test_formula_from_name_and_value():
     formula = AirtableParams.FormulaParam.from_name_and_value("COL", "VAL")
     assert formula == r"{COL}='VAL'"
+
+    formula = AirtableParams.FormulaParam.from_name_and_value("COL", "'VAL'")
+    assert formula == r"{COL}='\'VAL\''"
+
+    formula = AirtableParams.FormulaParam.from_name_and_value("COL", "\\'VAL\\'")
+    assert formula == r"{COL}='\'VAL\''"
 
     formula = AirtableParams.FormulaParam.from_name_and_value("COL", 8)
     assert formula == r"{COL}=8"


### PR DESCRIPTION
Added handling to escape single quotes in formula field values, if not already escaped, as well as associated test cases. This closes the original pull request (https://github.com/gtalarico/airtable-python-wrapper/pull/111) per our conversation in March. I realize it took me a while to get to it... thanks for your patience. 

Let me know what you think - feedback welcome!